### PR TITLE
add `g:choosewin_skip_on_single_win`.

### DIFF
--- a/autoload/choosewin.vim
+++ b/autoload/choosewin.vim
@@ -157,6 +157,10 @@ function! s:cw.start(winnums, ...) "{{{1
   if g:choosewin_return_on_single_win && len(a:winnums) ==# 1
     return
   endif
+  if g:choosewin_skip_on_single_win && len(a:winnums) ==# 1
+    silent execute a:winnums[0] 'wincmd w'
+    return
+  endif
   let winlabel    = !empty(a:0) ? a:1 : g:choosewin_label
 
   let self.options    = {}

--- a/doc/choosewin.txt
+++ b/doc/choosewin.txt
@@ -120,6 +120,11 @@ VARIABLES						*choowsewin-variables*
 	Type: |Number|
 	Set 1 to return immediately when number of window is 1.
 
+*g:choosewin_skip_on_single_win*
+	Default: 1
+	Type: |Number|
+	Set 1 to choose immediately when number of window is 1.
+
 ==============================================================================
 FUNCTIONS						*choowsewin-functions*
 

--- a/plugin/choosewin.vim
+++ b/plugin/choosewin.vim
@@ -21,6 +21,7 @@ let s:options = {
       \      { 'gui': ['LimeGreen', 'black', 'bold'], 'cterm': [ 9, 16] },
       \ 'g:choosewin_color_other': { 'gui': ['gray20', 'black'], 'cterm': [ 240, 0] },
       \ 'g:choosewin_return_on_single_win': 0,
+      \ 'g:choosewin_skip_on_single_win': 1,
       \ 'g:choosewin_label': 'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
       \ 'g:choosewin_tablabel': '1234567890',
       \ }


### PR DESCRIPTION
g:choosewin_return_on_single_win とは別に、「対象ウィンドウが一つのみの場合、"choose" せずにそのウィンドウに移動する」オプションを追加しました。

vim-users.jp を拝見させていただいているのですが、vimfiler との連携時にその方が都合がいい場合が多いかと思われます。

設定例:

``` VimL
" choosewin/open.
let s:action = { 'is_selectable' : 0 }
function! s:action.func(candidate)
  call choosewin#start(filter(range(1, winnr('$')), '!s:is_ignore_window(v:val)'))
  execute printf('edit %s', fnameescape(a:candidate.action__path))
endfunction
call unite#custom_action('file', 'choosewin/open', s:action)

" choosewin/split.
let s:action = { 'is_selectable' : 0 }
function! s:action.func(candidate)
  call choosewin#start(filter(range(1, winnr('$')), '!s:is_ignore_window(v:val)'))
  execute printf('split %s', fnameescape(a:candidate.action__path))
endfunction
call unite#custom_action('file', 'choosewin/split', s:action)

" choosewin/vsplit.
let s:action = { 'is_selectable' : 0 }
function! s:action.func(candidate)
  call choosewin#start(filter(range(1, winnr('$')), '!s:is_ignore_window(v:val)'))
  execute printf('vsplit %s', fnameescape(a:candidate.action__path))
endfunction
call unite#custom_action('file', 'choosewin/vsplit', s:action)

" check ignore window by filetype.
function! s:is_ignore_window(winnr)
  return index(["unite", "vimfiler", "vimshell"], getbufvar(winbufnr(a:winnr), "&filetype")) >= 0
endfunction
```

最後に、quickhl や choosewin などすばらしいプラグインを作っていただき感謝です。
今後とも愛用させていただきます！
