### PR TITLE
Handle interrupts

### DIFF
--- a/autoload/choosewin.vim
+++ b/autoload/choosewin.vim
@@ -74,6 +74,9 @@ function! s:cw.start(wins, ...) "{{{1
     else
       let self.previous = [ self.src.tab, self.src.win ]
     endif
+  catch /\v^Vim:Interrupt$/
+    call self.label_clear()
+    call self.action.do_cancel()
   catch /\v^(RETURN|CANCELED)$/
   catch
     let self.exception = v:exception


### PR DESCRIPTION
Interrupting `choosewin` with `CTRL-C` does not restore the previous
statusline.

This commit handles Vim interrupts by catching the exception as
suggested by `:help catch-interrupt` and calling `self.label_clear()`
and `self.action.do_cancel()`.

This pull request closes #13 