### PR TITLE
Use Neovim 0.1.4-acc5d08b new true-color setting

### DIFF
--- a/autoload/choosewin/hlmanager.vim
+++ b/autoload/choosewin/hlmanager.vim
@@ -24,7 +24,7 @@ unlet! s:define_type_checker
 
 let s:SCREEN = (has('gui_running')
       \ || (has('termtruecolor') && &guicolors == 1)
-      \ || (has('nvim') && $NVIM_TUI_ENABLE_TRUE_COLOR == 1))
+      \ || (has('nvim') && has('termguicolors') && &termguicolors == 1))
       \ ? 'gui' : 'cterm'
 
 " Main:


### PR DESCRIPTION
Neovim [v0.1.4-acc5d08b](https://github.com/neovim/neovim/commit/acc5d08b371c9521d63aa4a37cce9ffab451d21d) introduces the `termguicolors` setting and deprecates `NVIM_TUI_ENABLE_TRUE_COLOR `. This adapts to the new option setting. Fixes #29 