### PR TITLE
Fix vim true colors support in term

### DIFF
--- a/autoload/choosewin/hlmanager.vim
+++ b/autoload/choosewin/hlmanager.vim
@@ -23,8 +23,7 @@ call s:define_type_checker()
 unlet! s:define_type_checker
 
 let s:SCREEN = (has('gui_running')
-      \ || (has('termtruecolor') && &guicolors == 1)
-      \ || (has('nvim') && has('termguicolors') && &termguicolors == 1))
+      \ || (has('termtruecolor') && &termguicolors)
       \ ? 'gui' : 'cterm'
 
 " Main:


### PR DESCRIPTION
@t9md I have fix vim true colors support. both vim and neovim use `'termguicolors'` as the option for true colors feature in term.