### PR TITLE
Fix incorrect feature detection introduced in f511b583e

### DIFF
--- a/autoload/choosewin/hlmanager.vim
+++ b/autoload/choosewin/hlmanager.vim
@@ -22,9 +22,12 @@ endfunction
 call s:define_type_checker()
 unlet! s:define_type_checker
 
-let s:SCREEN = (has('gui_running')
-      \ || (has('termtruecolor') && &termguicolors))
-      \ ? 'gui' : 'cterm'
+" Copied from vim-airline's airline#init#gui_mode function
+let s:SCREEN = (has('gui_running') ||
+      \ (has('termtruecolor') && &guicolors == 1) ||
+      \ (has('termguicolors') && &termguicolors == 1) ||
+      \ (has('nvim') && exists('$NVIM_TUI_ENABLE_TRUE_COLOR')
+      \ && !exists('+termguicolors'))) ? 'gui' : 'cterm'
 
 " Main:
 let s:hlmgr = {}


### PR DESCRIPTION
Commit f511b583e0cca63e1bfbede948611810291026dc introduced an incorrect feature detection. 

This patch copies from the popular [vim-airline](https://github.com/vim-airline/vim-airline) plugin which uses `gui` if one of these features/settings are detected:

* Running in a GUI
* `termtruecolor` feature exists and `guicolors` is enabled
* `termguicolors` feature exists and `termguicolors` is enabled
* Running in Neovim and `$NVIM_TUI_ENABLE_TRUE_COLOR` is enabled (deprecated)
