### PR TITLE
Hide cursorcolumn and colorcolumn during overlay display

### DIFF
--- a/autoload/choosewin/overlay.vim
+++ b/autoload/choosewin/overlay.vim
@@ -8,9 +8,10 @@ let s:FONT_MAX = {
 " These are variables that need to be changed for overlay work properly.
 let s:vim_options = {}
 let s:vim_options.global = {
-      \ '&cursorline': 0,
-      \ '&scrolloff':  0,
-      \ '&lazyredraw': 1,
+      \ '&cursorline':   0,
+      \ '&cursorcolumn': 0,
+      \ '&scrolloff':    0,
+      \ '&lazyredraw':   1,
       \ }
 let s:vim_options.buffer = {
       \ '&modified':   0,
@@ -23,6 +24,7 @@ let s:vim_options.window = {
       \ '&list':         0,
       \ '&foldenable':   0,
       \ '&conceallevel': 0,
+      \ '&colorcolumn':  '',
       \ }
 
 " Util:


### PR DESCRIPTION
Before:
![screenshot from 2017-11-25 17-22-30](https://user-images.githubusercontent.com/931757/33232381-b214c3a0-d205-11e7-8935-d6b9e159f26a.png)

After:
![screenshot from 2017-11-25 17-24-50](https://user-images.githubusercontent.com/931757/33232391-d4b64fd2-d205-11e7-9bad-a6846e8957b5.png)
