### PR TITLE
Fix wrong numbering in doc file

### DIFF
--- a/doc/choosewin.txt
+++ b/doc/choosewin.txt
@@ -229,7 +229,7 @@ All config options in this section are set in 'autoload/choosewin/config.vim'.
 	  1. Substitutes tabs with space
 	  2. Append space to rendering area
 	  3. Replaces multibyte chars.
-	  3. Appends an empty line to the EOF.
+	  4. Appends an empty line to the EOF.
 	- Then it highlights the caption font with matchadd()
 	- When done, it reverts all changes.
 


### PR DESCRIPTION
In the documentation file, there was wrong numbering in the list of what aggressive means. It had 3 twice (1, 2, 3, 3) instead of being 3 and 4 (1, 2, 3, 4).
Simply changed the 3 into a 4.