### PR TITLE
Escape `<` characters in README

### DIFF
--- a/README-JP.md
+++ b/README-JP.md
@@ -35,17 +35,17 @@ let g:choosewin_overlay_clear_multibyte = 1
 
 ## choosewin 呼び出し後のキーマップのデフォルト
 
-| Key    | Action     | Description                   | 
-| ------ | ---------- | ----------------------------- | 
-| 0      | tab_first  | choose FIRST    tab           | 
-| [      | tab_prev   | choose PREVIOUS tab           | 
-| ]      | tab_next   | choose NEXT     tab           | 
-| $      | tab_last   | choose LAST     tab           | 
-| ;      | win_land   | land to current window        | 
-| -      | previous   | land to previous window       | 
-| s      | swap       | swap buffer with you chose *1 | 
-| `<CR>` | win_land   | land to current window        | 
-|        | <NOP>      | disable predefined keymap     | 
+| Key    | Action     | Description                   |
+| ------ | ---------- | ----------------------------- |
+| 0      | tab_first  | choose FIRST    tab           |
+| [      | tab_prev   | choose PREVIOUS tab           |
+| ]      | tab_next   | choose NEXT     tab           |
+| $      | tab_last   | choose LAST     tab           |
+| ;      | win_land   | land to current window        |
+| -      | previous   | land to previous window       |
+| s      | swap       | swap buffer with you chose *1 |
+| `<CR>` | win_land   | land to current window        |
+|        | `<NOP>`    | disable predefined keymap     |
 
 *1 'swap' を２回連続で呼び出した場合、直前(previous)の window のバッファとスワップします。
 例) デフォルトのキーマップでは、'ss' で直前のバッファとスワップします。

--- a/README.md
+++ b/README.md
@@ -34,19 +34,19 @@ More configuration options are explained in the help file. See `:help choosewin`
 
 ## Default keymapings in choosewin mode
 
-| Key  | Action     | Description                   |
-| ---- | ---------- | ----------------------------- |
-| 0    | tab_first  | Select FIRST    tab           |
-| [    | tab_prev   | Select PREVIOUS tab           |
-| ]    | tab_next   | Select NEXT     tab           |
-| $    | tab_last   | Select LAST     tab           |
-| x    | tab_close  | Close current tab             |
-| ;    | win_land   | Navigate to current window    |
-| -    | previous   | Naviage to previous window    |
-| s    | swap       | Swap windows               #1 |
-| S    | swap_stay  | Swap windows but stay      #1 |
-| <CR> | win_land   | Navigate to current window    |
-|      | <NOP>      | Disable predefined keymap     |
+| Key    | Action     | Description                   |
+| ------ | ---------- | ----------------------------- |
+| 0      | tab_first  | Select FIRST    tab           |
+| [      | tab_prev   | Select PREVIOUS tab           |
+| ]      | tab_next   | Select NEXT     tab           |
+| $      | tab_last   | Select LAST     tab           |
+| x      | tab_close  | Close current tab             |
+| ;      | win_land   | Navigate to current window    |
+| -      | previous   | Naviage to previous window    |
+| s      | swap       | Swap windows               #1 |
+| S      | swap_stay  | Swap windows but stay      #1 |
+| `<CR>` | win_land   | Navigate to current window    |
+|        | `<NOP>`    | Disable predefined keymap     |
 
 *1 If you select 'swap' again, you will swap with the previous window's buffer ex) using the default keymap, typing double 's'(ss) swaps with the previous window.
 


### PR DESCRIPTION
`<CR>` and `<NOP>` aren't visible on GitHub because it's treated as HTML tags.