### PR TITLE
Fix get <SID> (error occurred called by another plugin)

### DIFF
--- a/autoload/choosewin/util.vim
+++ b/autoload/choosewin/util.vim
@@ -1,6 +1,6 @@
 function! s:SID() "{{{1
   let fullname = expand("<sfile>")
-  return matchstr(fullname, '<SNR>\d\+_')
+  return matchstr(fullname, '<SNR>\d\+_\zeSID$')
 endfunction
 "}}}
 let s:sid = s:SID()


### PR DESCRIPTION
Maybe, [patch 8.2.1297](https://github.com/vim/vim/commit/a5d0423fa16f18b4576a2a07e50034e489587a7d) changed `expand("<sfile>")` specification

## reproduced

1. add debug code
``` diff
  function! s:SID()
   let fullname = expand("<sfile>")
+  echo fullname
   return matchstr(fullname, '<SNR>\d\+_')
  endfunction
```

2. prepare vim-choosewin, and another plugin(vimfiler.vim)
3. lunch vim.
4. open 2 or more windows.
5. `:VimFilerExploler`
6. open some file by vimfiler.

## result

### gvim 8.2.1303(Windows 10)
Error:
`function vimfiler#mappings#do_switch_action[2]..<SNR>247_switch[28]..function vimfiler#mappings#do_switch_action[2]..<SNR>247_switch[24]..script C:\Users\htakiza.PJOPS\vimfiles\pack\m\start\vim-choosewin\autoload\choosewin.vim[8]..function choosewin#util#get の処理中にエラーが検出されました:`

debug code output:
`function vimfiler#mappings#do_switch_action[2]..<SNR>247_switch[24]..script C:\path\to\vimfiles\pack\m\start\vim-choosewin\autoload\choosewin.vim[8]..C:\path\to\vimfiles\pack\m\start\vim-choosewin\autoload\choosewin\util.vim[7]..function <SNR>262_SID`

### gvim 8.2.1294(Windows 10)
Error:
not occurred

debug code output:
`function <SNR>236_SID`
