### PR TITLE
Add `g:choosewin_highlight_on_init` to control highlighting 

### DIFF
--- a/autoload/choosewin/color.vim
+++ b/autoload/choosewin/color.vim
@@ -8,6 +8,10 @@ function! s:Color.init() "{{{1
   let config   = choosewin#config#get()
   let self.mgr = choosewin#hlmanager#new('')
 
+  if !config['highlight_on_init']
+    return
+  endif
+
   let colors = {
         \ "Label":          config['color_label'],
         \ "LabelCurrent":   config['color_label_current'],

--- a/autoload/choosewin/config.vim
+++ b/autoload/choosewin/config.vim
@@ -21,6 +21,7 @@ let s:default = {
       \ 'active':                  0,
       \ 'debug':                   0,
       \ 'label_fill':              0,
+      \ 'highlight_on_init':       1,
       \ 'color_label':            { 'gui': ['DarkGreen', 'white', 'bold'], 'cterm': [ 22, 15,'bold'] },
       \ 'color_label_current':    { 'gui': ['LimeGreen', 'black', 'bold'], 'cterm': [ 40, 16, 'bold'] },
       \ 'color_overlay':          { 'gui': ['DarkGreen', 'DarkGreen' ], 'cterm': [ 22, 22 ] },


### PR DESCRIPTION
This PR adds the `g:choosewin_highlight_on_init` option that can be used to control highlighting

By default, the plugin highlights control elements on initialisation and overrides any highlighting rules from the `$VIMRC` 
There is a way to specify colours(e.g. `g:choosewin_color_label`, etc), but it doesn't allow to link to specific highlighting rules
So, for example, this
```vim
augroup my_colorscheme
  autocmd!

  autocmd ColorScheme *  hi! link ChooseWinOther MyRule
augroup END
```
simply gets overridden with the built-in highlighting rules

This PR is more a proof of concept, as I haven't added tests(if any) and documentation
Maybe there is a better way that I am not aware of to achieve this without this PR, so please advise

My original idea was to make [this call](https://github.com/t9md/vim-choosewin/blob/f91cdb9be92ce3bb9bccba16e8c659d5e8d7454f/plugin/choosewin.vim#L13-L16) optional but it looks like we [explicitly call `call choosewin#color#init()` in the `choosewin#start`](https://github.com/t9md/vim-choosewin/blob/master/autoload/choosewin.vim#L91)